### PR TITLE
Improve boot speed and CPU usage

### DIFF
--- a/bin/rubyshell
+++ b/bin/rubyshell
@@ -1,5 +1,7 @@
-#!/usr/bin/env ruby
+#!/usr/bin/env -S ruby --disable-gems
 # frozen_string_literal: true
+
+$LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
 
 require "rubyshell"
 

--- a/lib/rubyshell.rb
+++ b/lib/rubyshell.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "logger"
-
 require_relative "rubyshell/version"
 require_relative "rubyshell/command"
 require_relative "rubyshell/chainer"
@@ -43,6 +41,8 @@ module RubyShell
     attr_writer :logger
 
     def logger
+      require "logger"
+
       @logger ||= Logger.new($stdout)
     end
 

--- a/lib/rubyshell/chainer.rb
+++ b/lib/rubyshell/chainer.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "debug"
 module RubyShell
   class Chainer
     attr_reader :parts, :options

--- a/lib/rubyshell/terminal_executor.rb
+++ b/lib/rubyshell/terminal_executor.rb
@@ -4,8 +4,6 @@ require "open3"
 
 module RubyShell
   module TerminalExecutor
-    SELECT_TIMEOUT = Rational(1, 20).freeze
-
     def self.capture(command, options) # rubocop:disable Metris/MethodLength,Metrics/CyclomaticComplexity,Metrix/AbcSize,Metrics/PerceivedComplexity
       stdin_value = if options[:_stdin].is_a?(RubyShell::Command) || options[:_stdin].is_a?(RubyShell::Chainer)
                       options[:_stdin].exec
@@ -27,17 +25,11 @@ module RubyShell
         error = +""
         ios = { stdout => output, stderr => error }
 
-        status = nil
-
-        # What was my idea here:
-        # If has not any io readable and the program exited in the previous loop, stop
+        # Block until a pipe has data (or hits EOF) instead of polling, so we
+        # dont burn a CPU core spinning while the command runs.
+        # EOF on both pipes empties ios and ends the loop, then we reap the exit status
         until ios.empty?
-          status ||= w_thread.join(0)
-
-          readable, = IO.select(ios.keys, nil, nil, 0)
-
-          break if !readable && status
-          next unless readable
+          readable, = IO.select(ios.keys)
 
           readable.each do |io|
             loop do

--- a/lib/rubyshell/terminal_executor.rb
+++ b/lib/rubyshell/terminal_executor.rb
@@ -4,6 +4,8 @@ require "open3"
 
 module RubyShell
   module TerminalExecutor
+    SELECT_TIMEOUT = Rational(1, 20).freeze
+
     def self.capture(command, options) # rubocop:disable Metris/MethodLength,Metrics/CyclomaticComplexity,Metrix/AbcSize,Metrics/PerceivedComplexity
       stdin_value = if options[:_stdin].is_a?(RubyShell::Command) || options[:_stdin].is_a?(RubyShell::Chainer)
                       options[:_stdin].exec
@@ -25,11 +27,17 @@ module RubyShell
         error = +""
         ios = { stdout => output, stderr => error }
 
-        # Block until a pipe has data (or hits EOF) instead of polling, so we
-        # dont burn a CPU core spinning while the command runs.
-        # EOF on both pipes empties ios and ends the loop, then we reap the exit status
+        status = nil
+
+        # What was my idea here:
+        # If has not any io readable and the program exited in the previous loop, stop
         until ios.empty?
-          readable, = IO.select(ios.keys)
+          status ||= w_thread.join(0)
+
+          readable, = IO.select(ios.keys, nil, nil, SELECT_TIMEOUT)
+
+          break if !readable && status
+          next unless readable
 
           readable.each do |io|
             loop do


### PR DESCRIPTION
Startup ~17x faster (from ~100ms to ~6ms)

- Removed the require debug, saving ~80ms
- Bypassed the RubyGems loading, saving ~20ms
- Made logger be lazy loaded, saving ~3ms

Reduced CPU usage while waiting for return of commands, before was using 100% of a core, now 0% (while waiting ios)