### PR TITLE
fix: support symbolic chain operators on ruby 2.6

### DIFF
--- a/lib/rubyshell/chainer.rb
+++ b/lib/rubyshell/chainer.rb
@@ -28,7 +28,7 @@ module RubyShell
     end
 
     def method_missing(method_name, *args, &block)
-      if method_name.start_with?(/[^A-Za-z0-9]/)
+      if method_name.to_s.match?(/\A[^A-Za-z0-9]/)
         handle_chain(method_name, args.first)
       else
         super

--- a/lib/rubyshell/command.rb
+++ b/lib/rubyshell/command.rb
@@ -41,7 +41,7 @@ module RubyShell
     private
 
     def method_missing(method_name, *args, &block)
-      if method_name.start_with?(/[^A-Za-z0-9]/)
+      if method_name.to_s.match?(/\A[^A-Za-z0-9]/)
         RubyShell::Chainer.new(self).send(method_name, *args, block)
       else
         super

--- a/spec/chainer_spec.rb
+++ b/spec/chainer_spec.rb
@@ -10,6 +10,28 @@ RSpec.describe RubyShell do
   end
 
   describe "Validating Chains" do
+    context "when chaining several commands with symbolic pipe operators" do
+      def subject_call
+        sh do
+          (printf!("hello") | cat! | cat!).exec
+        end
+      end
+
+      it "executes every command in the pipeline" do
+        expect(subject_call).to eq("hello")
+      end
+    end
+
+    context "when an unknown ordinary method is called on a command" do
+      def subject_call
+        RubyShell::Command.new("printf", "hello").unknown_chain_method
+      end
+
+      it "raises for the requested method instead of operator detection" do
+        expect { subject_call }.to raise_error(NoMethodError, /unknown_chain_method/)
+      end
+    end
+
     context "when counting files in current folder" do
       def subject_call
         sh do


### PR DESCRIPTION
The project declares Ruby 2.6 support, but piping command objects fails there before reaching the shell: `method_missing` receives a Symbol and calls `start_with?` on it.

Normalize the method name to a string and use an anchored regex in both Command and Chainer. This preserves the existing operator classification while supporting the declared minimum Ruby version. Add regression coverage for a three-command pipeline and ordinary missing-method fallback.

Validation on Ruby 2.6.10/macOS:
- Before: a real `printf | cat | cat` pipeline raises `NoMethodError: undefined method start_with? for :|:Symbol`.
- After: pipeline rendering, actual execution, the bang-method DSL pipeline, and ordinary missing-method fallback all pass in a temporary directory.
- All three edited Ruby files pass syntax checks; `git diff --check` passes.
- Full RSpec/RuboCop was not run locally: the project's current Bundler/debug tooling is not available in the system Ruby environment. Upstream CI remains necessary.

No command escaping or operator allowlist change is included. Prepared with AI assistance. This is independent of PR #77's debug-failure work.
